### PR TITLE
CAS #948 -- NPE during SPNEGO Authentication

### DIFF
--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
@@ -152,7 +152,9 @@ public final class SpnegoCredential implements Credential, Serializable {
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(this.getInitToken()) ^ Arrays.hashCode(this.getNextToken()) ^ this.principal.hashCode();
+    	int hash = 3;
+    	if (this.principal != null) hash = this.principal.hashCode();
+        return Arrays.hashCode(this.getInitToken()) ^ Arrays.hashCode(this.getNextToken()) ^ hash;
     }
 
     /**

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/principal/SpnegoCredential.java
@@ -152,8 +152,10 @@ public final class SpnegoCredential implements Credential, Serializable {
 
     @Override
     public int hashCode() {
-    	int hash = 3;
-    	if (this.principal != null) hash = this.principal.hashCode();
+        int hash = 3;
+        if (this.principal != null) {
+            hash = this.principal.hashCode();
+        }
         return Arrays.hashCode(this.getInitToken()) ^ Arrays.hashCode(this.getNextToken()) ^ hash;
     }
 


### PR DESCRIPTION
Modify hashCode function of SpnegoCredential in order to avoid NPE when principal has not yet been resolved.