### PR TITLE
Updates

### DIFF
--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/BaseSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/BaseSpnegoKnownClientSystemsFilterAction.java
@@ -30,6 +30,8 @@ import org.springframework.webflow.execution.RequestContext;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -45,6 +47,8 @@ import java.util.regex.Pattern;
  * @since 4.1
  */
 public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
+    private static final int DEFAULT_TIMEOUT = 5000;
+
     /** Logger instance. **/
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -56,6 +60,10 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
 
     /** The remote ip address. **/
     private String remoteIp;
+ 
+    /** Timeout for DNS Requests. **/
+    private long timeout = DEFAULT_TIMEOUT;
+
 
 
     /**
@@ -106,7 +114,7 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
      * {@link #no()} otherwise.
      */
     @Override
-    protected final Event doExecute(@NotNull final RequestContext context) {
+    protected final Event doExecute(final RequestContext context) {
         this.remoteIp = getRemoteIp(context);
         logger.debug("Current user IP {}", this.remoteIp);
         return shouldDoSpnego() ? yes() : no();
@@ -186,5 +194,110 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
                 .append("alternativeRemoteHostAttribute", this.alternativeRemoteHostAttribute)
                 .append("remoteIp", this.remoteIp)
                 .toString();
+    }
+
+    /**
+     * Set timeout (ms) for DNS requests; valuable for heterogeneous environments employing
+     * fall-through authentication mechanisms.
+     * @param timeout # of milliseconds to wait for a DNS request to return
+     */
+    public final void setTimeout(final long timeout) {
+        this.timeout = timeout;
+    }
+
+    /**
+     * Convenience method to perform a reverse DNS lookup. Threads the request
+     * through a custom Runnable class in order to prevent inordinately long
+     * user waits while performing reverse lookup.
+     * @return the remote host name
+     */
+    protected String getRemoteHostName() {
+        final ReverseDNS revDNS = new ReverseDNS(getRemoteIp());
+
+        final Thread t = new Thread(revDNS);
+        t.start();
+
+        try {
+            t.join(this.timeout);
+        } catch (final InterruptedException e) {
+            logger.debug("Threaded lookup failed.  Defaulting to IP {}.", getRemoteIp(), e);
+        }
+
+        final String remoteHostName = revDNS.get();
+        logger.debug("Found remote host name {}.", remoteHostName);
+
+        return StringUtils.isNotEmpty(remoteHostName) ? remoteHostName : getRemoteIp();
+    }
+
+
+    /**
+     *  Utility class to perform DNS work in a threaded, timeout-able way
+     *  Adapted from: http://thushw.blogspot.com/2009/11/resolving-domain-names-quickly-with.html.
+     *
+     *  @author Sean Baker sean.baker@usuhs.edu
+     *  @author Misagh Moayyed
+     *  @since 4.1
+     */
+    private static final class ReverseDNS implements Runnable {
+
+        /** Logger instance. **/
+        private static final Logger LOGGER = LoggerFactory.getLogger(ReverseDNS.class);
+
+        /** Remote user IP address. **/
+        private final String ipAddress;
+
+        /** Remote user hostname. **/
+        private String hostName;
+
+        /**
+         * Simple constructor which also pre-sets hostName attribute for failover situations.
+         * @param ipAddress the ip address on which reverse DNS will be done.
+         */
+        public ReverseDNS(final String ipAddress) {
+            this.ipAddress = ipAddress;
+            this.hostName = ipAddress;
+        }
+
+        /**
+         * Runnable implementation to thread the work done in this class, allowing the
+         * implementer to set a thread timeout and thereby short-circuit the lookup.
+         */
+        @Override
+        public void run() {
+            try {
+                LOGGER.debug("Attempting to resolve {}", this.ipAddress);
+                final InetAddress address = InetAddress.getByName(this.ipAddress);
+                set(address.getCanonicalHostName());
+            } catch (final UnknownHostException e) {
+                /** N/A -- Default to IP address, but that's already done. **/
+                LOGGER.debug("Unable to identify the canonical hostname for ip address.", e);
+            }
+        }
+
+        /**
+         * Glorified setter with logging.
+         * @param hostName the resolved hostname
+         */
+        public synchronized void set(final String hostName) {
+            LOGGER.trace("ReverseDNS -- Found hostName: {}.", hostName);
+            this.hostName = hostName;
+        }
+
+        /**
+         * Getter method to provide result of lookup.
+         * @return the remote host name, or the IP address if name not found
+         */
+        public synchronized String get() {
+            return this.hostName;
+        }
+
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("ipAddress", this.ipAddress)
+                    .append("hostName", this.hostName)
+                    .toString();
+        }
     }
 }

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/HostNameSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/HostNameSpnegoKnownClientSystemsFilterAction.java
@@ -20,14 +20,7 @@
 package org.jasig.cas.support.spnego.web.flow.client;
 
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.validation.constraints.NotNull;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.regex.Pattern;
 
 /**
@@ -40,11 +33,6 @@ import java.util.regex.Pattern;
  * @since 4.1
  */
 public class HostNameSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownClientSystemsFilterAction {
-    private static final int DEFAULT_TIMEOUT = 5000;
-
-    /** Timeout for DNS Requests. **/
-    private long timeout = DEFAULT_TIMEOUT;
-
     private final Pattern hostNamePatternString;
 
     /**
@@ -69,111 +57,5 @@ public class HostNameSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnow
         final String hostName = getRemoteHostName();
         logger.debug("Retrieved host name for the remote ip is {}", hostName);
         return this.hostNamePatternString.matcher(hostName).find();
-    }
-
-
-    /**
-     * Set timeout (ms) for DNS requests; valuable for heterogeneous environments employing
-     * fall-through authentication mechanisms.
-     * @param timeout # of milliseconds to wait for a DNS request to return
-     */
-    public final void setTimeout(final long timeout) {
-        this.timeout = timeout;
-    }
-
-    /**
-     * Convenience method to perform a reverse DNS lookup. Threads the request
-     * through a custom Runnable class in order to prevent inordinately long
-     * user waits while performing reverse lookup.
-     * @return the remote host name
-     */
-    private String getRemoteHostName() {
-        final ReverseDNS revDNS = new ReverseDNS(getRemoteIp());
-
-        final Thread t = new Thread(revDNS);
-        t.start();
-
-        try {
-            t.join(this.timeout);
-        } catch (final InterruptedException e) {
-            logger.debug("Threaded lookup failed.  Defaulting to IP {}.", getRemoteIp(), e);
-        }
-
-        final String remoteHostName = revDNS.get();
-        logger.debug("Found remote host name {}.", remoteHostName);
-
-        return StringUtils.isNotEmpty(remoteHostName) ? remoteHostName : getRemoteIp();
-    }
-
-
-    /**
-     *  Utility class to perform DNS work in a threaded, timeout-able way
-     *  Adapted from: http://thushw.blogspot.com/2009/11/resolving-domain-names-quickly-with.html.
-     *
-     *  @author Sean Baker sean.baker@usuhs.edu
-     *  @author Misagh Moayyed
-     *  @since 4.1
-     */
-    private static final class ReverseDNS implements Runnable {
-
-        /** Logger instance. **/
-        private static final Logger LOGGER = LoggerFactory.getLogger(ReverseDNS.class);
-
-        /** Remote user IP address. **/
-        private final String ipAddress;
-
-        /** Remote user hostname. **/
-        private String hostName;
-
-        /**
-         * Simple constructor which also pre-sets hostName attribute for failover situations.
-         * @param ipAddress the ip address on which reverse DNS will be done.
-         */
-        public ReverseDNS(final String ipAddress) {
-            this.ipAddress = ipAddress;
-            this.hostName = ipAddress;
-        }
-
-        /**
-         * Runnable implementation to thread the work done in this class, allowing the
-         * implementer to set a thread timeout and thereby short-circuit the lookup.
-         */
-        @Override
-        public void run() {
-            try {
-                LOGGER.debug("Attempting to resolve {}", this.ipAddress);
-                final InetAddress address = InetAddress.getByName(this.ipAddress);
-                set(address.getCanonicalHostName());
-            } catch (final UnknownHostException e) {
-                /** N/A -- Default to IP address, but that's already done. **/
-                LOGGER.debug("Unable to identify the canonical hostname for ip address.", e);
-            }
-        }
-
-        /**
-         * Glorified setter with logging.
-         * @param hostName the resolved hostname
-         */
-        public synchronized void set(final String hostName) {
-            LOGGER.trace("ReverseDNS -- Found hostName: {}.", hostName);
-            this.hostName = hostName;
-        }
-
-        /**
-         * Getter method to provide result of lookup.
-         * @return the remote host name, or the IP address if name not found
-         */
-        public synchronized String get() {
-            return this.hostName;
-        }
-
-
-        @Override
-        public String toString() {
-            return new ToStringBuilder(this)
-                    .append("ipAddress", this.ipAddress)
-                    .append("hostName", this.hostName)
-                    .toString();
-        }
     }
 }

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
@@ -115,7 +115,7 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
     @Override
     protected boolean shouldDoSpnego() {
         Connection connection = null;
-        final String remoteHostName = this.getRemoteHostName ();
+        final String remoteHostName = getRemoteHostName();
         try {
             connection = createConnection();
             logger.debug("Connected to {}. Searching {}", this.connectionConfig.getLdapUrl(), this.searchRequest);
@@ -146,9 +146,9 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
      * @return true if attribute value exists and has a value
      */
     protected boolean verifySpnegoAttribute(final Response<SearchResult> searchResult) {
-    	if (searchResult.getResult() == null || searchResult.getResult().getEntries().size() < 1) {
-    		return false;
-    	}
+        if (searchResult.getResult() == null || searchResult.getResult().getEntries().size() < 1) {
+            return false;
+        }
         final LdapEntry entry = searchResult.getResult().getEntry();
         final LdapAttribute attribute = entry.getAttribute(this.spnegoAttributeName);
         return attribute != null && StringUtils.isNotBlank(attribute.getStringValue());


### PR DESCRIPTION
Wow, @mmoayyed you got ahead quick!

Suggesting a few things which were valuable locally:
 -- Moved hostname lookup into the base class, as LDAP lookups really should be done on the basis of the machine name vs. IP address; only custom AD implementations store IP.
 -- Add parameter to LDAP lookup function.
 -- Drop @NotNull constraint from doExecute; this appears to fail at runtime as we're not supposed to override the base class' constraints.
 -- Add NPE check to LDAP class; that one bit me a few times.