### PR TITLE
Tweaks

### DIFF
--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/BaseSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/BaseSpnegoKnownClientSystemsFilterAction.java
@@ -53,7 +53,7 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /** Pattern of ip addresses to check. **/
-    protected Pattern ipsToCheckPattern;
+    private Pattern ipsToCheckPattern;
 
     /** Alternative remote host attribute. **/
     private String alternativeRemoteHostAttribute;
@@ -63,7 +63,7 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
  
     /** Timeout for DNS Requests. **/
     private long timeout = DEFAULT_TIMEOUT;
-
+    
     /**
      * Instantiates a new Base.
      */
@@ -122,7 +122,15 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
      * @return true
      */
     protected boolean shouldDoSpnego() {
-        return shouldCheckIp();
+        return ipPatternCanBeChecked() && ipPatternMatches();
+    }
+    
+    /**
+     * Base class definition for whether the IP should be checked or not; overridable.
+     * @return whether or not the IP can / should be matched against the pattern
+     */
+    protected boolean ipPatternCanBeChecked() {
+        return (this.ipsToCheckPattern != null && StringUtils.isNotBlank(this.remoteIp));
     }
     
     /**
@@ -131,14 +139,12 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
      * for the local / first implementation regex made more sense.
      * @return whether the remote ip received should be queried
      */
-    protected boolean shouldCheckIp() {
-        if (this.ipsToCheckPattern != null && StringUtils.isNotBlank(this.remoteIp)) {
-            final Matcher matcher = this.ipsToCheckPattern.matcher(this.remoteIp);
-            if (matcher.find()) {
-                logger.debug("Remote IP address {} should be checked based on the defined pattern {}",
-                        this.remoteIp, this.ipsToCheckPattern.pattern());
-                return true;
-            }
+    protected boolean ipPatternMatches() {
+        final Matcher matcher = this.ipsToCheckPattern.matcher(this.remoteIp);
+        if (matcher.find()) {
+            logger.debug("Remote IP address {} should be checked based on the defined pattern {}",
+                    this.remoteIp, this.ipsToCheckPattern.pattern());
+            return true;
         }
         logger.debug("No pattern or remote IP defined, or pattern does not match remote IP [{}]",
                 this.remoteIp);

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/BaseSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/BaseSpnegoKnownClientSystemsFilterAction.java
@@ -69,7 +69,6 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
      */
     public BaseSpnegoKnownClientSystemsFilterAction() {}
 
-
     /**
      * Instantiates a new Base.
      *
@@ -115,16 +114,24 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
     protected final Event doExecute(final RequestContext context) {
         this.remoteIp = getRemoteIp(context);
         logger.debug("Current user IP {}", this.remoteIp);
-        return shouldDoSpnego() ? yes() : no();
+        return shouldCheckIP() && shouldDoSpnego() ? yes() : no();
     }
 
+    /**
+     * Default implementation -- always perform SPNEGO if IP check passed.
+     * @return true
+     */
+    protected boolean shouldDoSpnego() {
+        return true;
+    }
+    
     /**
      * Simple pattern match to determine whether an IP should be checked.
      * Could stand to be extended to support "real" IP addresses and patterns, but
      * for the local / first implementation regex made more sense.
-     * @return whether the remote ip received should be ignored
+     * @return whether the remote ip received should be queried
      */
-    protected boolean shouldDoSpnego() {
+    protected boolean shouldCheckIP() {
         if (this.ipsToCheckPattern != null && StringUtils.isNotBlank(this.remoteIp)) {
             final Matcher matcher = this.ipsToCheckPattern.matcher(this.remoteIp);
             if (matcher.find()) {
@@ -228,7 +235,6 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
         return StringUtils.isNotEmpty(remoteHostName) ? remoteHostName : getRemoteIp();
     }
 
-
     /**
      *  Utility class to perform DNS work in a threaded, timeout-able way
      *  Adapted from: http://thushw.blogspot.com/2009/11/resolving-domain-names-quickly-with.html.
@@ -289,7 +295,6 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
         public synchronized String get() {
             return this.hostName;
         }
-
 
         @Override
         public String toString() {

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/BaseSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/BaseSpnegoKnownClientSystemsFilterAction.java
@@ -53,7 +53,7 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /** Pattern of ip addresses to check. **/
-    private Pattern ipsToCheckPattern;
+    protected Pattern ipsToCheckPattern;
 
     /** Alternative remote host attribute. **/
     private String alternativeRemoteHostAttribute;
@@ -114,15 +114,15 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
     protected final Event doExecute(final RequestContext context) {
         this.remoteIp = getRemoteIp(context);
         logger.debug("Current user IP {}", this.remoteIp);
-        return shouldCheckIP() && shouldDoSpnego() ? yes() : no();
+        return shouldDoSpnego() ? yes() : no();
     }
 
     /**
-     * Default implementation -- always perform SPNEGO if IP check passed.
+     * Default implementation -- simply check the IP filter.
      * @return true
      */
     protected boolean shouldDoSpnego() {
-        return true;
+        return shouldCheckIp();
     }
     
     /**
@@ -131,7 +131,7 @@ public class BaseSpnegoKnownClientSystemsFilterAction extends AbstractAction {
      * for the local / first implementation regex made more sense.
      * @return whether the remote ip received should be queried
      */
-    protected boolean shouldCheckIP() {
+    protected boolean shouldCheckIp() {
         if (this.ipsToCheckPattern != null && StringUtils.isNotBlank(this.remoteIp)) {
             final Matcher matcher = this.ipsToCheckPattern.matcher(this.remoteIp);
             if (matcher.find()) {

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/HostNameSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/HostNameSpnegoKnownClientSystemsFilterAction.java
@@ -54,6 +54,9 @@ public class HostNameSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnow
      */
     @Override
     protected boolean shouldDoSpnego() {
+        if(this.ipsToCheckPattern != null && !shouldCheckIp()) {
+            return false;
+        }
         final String hostName = getRemoteHostName();
         logger.debug("Retrieved host name for the remote ip is {}", hostName);
         return this.hostNamePatternString.matcher(hostName).find();

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/HostNameSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/HostNameSpnegoKnownClientSystemsFilterAction.java
@@ -54,7 +54,7 @@ public class HostNameSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnow
      */
     @Override
     protected boolean shouldDoSpnego() {
-        if(this.ipsToCheckPattern != null && !shouldCheckIp()) {
+        if(!(ipPatternCanBeChecked() && ipPatternMatches())) {
             return false;
         }
         final String hostName = getRemoteHostName();

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
@@ -98,7 +98,7 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
     @Override
     protected boolean shouldDoSpnego() {
         Connection connection = null;
-        if(this.ipsToCheckPattern != null && !shouldCheckIp()) {
+        if(!(ipPatternCanBeChecked() && ipPatternMatches())) {
             return false;
         }
         final String remoteHostName = getRemoteHostName();

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
@@ -53,7 +53,7 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
 
     /** The search request. */
     protected final SearchRequest searchRequest;
-
+    
     /**
      * Instantiates new action. Initializes the default attribute
      * to be {@link #DEFAULT_SPNEGO_ATTRIBUTE}.
@@ -98,6 +98,9 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
     @Override
     protected boolean shouldDoSpnego() {
         Connection connection = null;
+        if(this.ipsToCheckPattern != null && !shouldCheckIp()) {
+            return false;
+        }
         final String remoteHostName = getRemoteHostName();
         try {
             connection = createConnection();

--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
@@ -34,7 +34,6 @@ import org.ldaptive.Operation;
 
 import javax.validation.constraints.NotNull;
 
-
 /**
  * Peek into an LDAP server and check for the existence of an attribute
  * in order to target invocation of spnego.
@@ -43,7 +42,6 @@ import javax.validation.constraints.NotNull;
  * @since 4.1
  */
 public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownClientSystemsFilterAction {
-
     /** Attribute name in LDAP to indicate spnego invocation. **/
     public static final String DEFAULT_SPNEGO_ATTRIBUTE = "distinguishedName";
 
@@ -82,7 +80,6 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
         this.spnegoAttributeName = spnegoAttributeName;
         this.searchRequest = searchRequest;
     }
-
 
     /**
      * Create and open a connection to ldap

--- a/cas-server-support-spnego/src/test/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterActionTests.java
+++ b/cas-server-support-spnego/src/test/java/org/jasig/cas/support/spnego/web/flow/client/LdapSpnegoKnownClientSystemsFilterActionTests.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * Test cases for {@link LdapSpnegoKnownClientSystemsFilterAction}.
  * @author Misagh Moayyed
+ * @since 4.1
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"/ldap-context.xml"})

--- a/cas-server-support-spnego/src/test/resources/ldap-context.xml
+++ b/cas-server-support-spnego/src/test/resources/ldap-context.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Licensed to Apereo under one or more contributor license
-  ~ agreements. See the NOTICE file distributed with this work
-  ~ for additional information regarding copyright ownership.
-  ~ Apereo licenses this file to you under the Apache License,
-  ~ Version 2.0 (the "License"); you may not use this file
-  ~ except in compliance with the License.  You may obtain a
-  ~ copy of the License at the following location:
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:c="http://www.springframework.org/schema/c"


### PR DESCRIPTION
-- Break IP filter check out into separate function in Base class to keep it in use in derivative classes (DNS lookups are expensive from a browser latency perspective)
-- Fix a couple of checkstyle & license compile issues.

FWIW, a fresh checkout can't run tests at the moment as the ldap-test jar isn't published to repo.  Not surprising, but to make sure it doesn't fall through cracks.